### PR TITLE
Add basic Error Bounary

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-error-boundary": "^2.3.1",
     "react-feather": "^2.0.8",
     "react-icons": "^3.10.0",
     "react-router-dom": "^5.2.0",

--- a/src/components/organisms/DisplayNavAndPage.tsx
+++ b/src/components/organisms/DisplayNavAndPage.tsx
@@ -1,7 +1,10 @@
 import { Box, Stack } from '@chakra-ui/core'
 import React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import NavSidebar from './NavSidebar'
+
+const ErrorOccured = () => <h1>Some error occured</h1>
 
 interface IDisplayNavAndPage {
   children: JSX.Element[] | JSX.Element
@@ -15,7 +18,9 @@ export default function DisplayNavAndPage({
         <NavSidebar active="dm" />
       </Box>
       <Stack spacing={8} marginTop="15px" width="100%">
-        {children}
+        <ErrorBoundary FallbackComponent={ErrorOccured}>
+          {children}
+        </ErrorBoundary>
       </Stack>
     </Stack>
   )

--- a/src/components/organisms/PinnedCommunities.tsx
+++ b/src/components/organisms/PinnedCommunities.tsx
@@ -1,0 +1,25 @@
+import { Box, Stack } from '@chakra-ui/core'
+import React from 'react'
+
+import GroupHeading from '../atoms/GroupHeading'
+import CommunityCardSmall from '../molecules/CommunityCardSmall'
+
+export default function PinnedCommunities() {
+  return (
+    <Stack>
+      <GroupHeading>Pinned Communities</GroupHeading>
+      <Stack direction="row" flexWrap="wrap">
+        {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => {
+          return (
+            <Box margin="10px" key={i}>
+              <CommunityCardSmall
+                title="Rapid"
+                totalMembers={1234}
+              ></CommunityCardSmall>
+            </Box>
+          )
+        })}
+      </Stack>
+    </Stack>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,7 +1090,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
   integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
@@ -11524,6 +11524,13 @@ react-draggable@^4.0.3:
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"
+
+react-error-boundary@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-2.3.1.tgz#bd6c8a9777224b6a1153c5f63e1ac86bf039f657"
+  integrity sha512-w1i++MM5GV6WTnM3MtLdw9CNXxqydkZwbwNDT9GBFBaWs0sp21z27DGIevb3fism1T+LGfdWgTFlhaq7G1pIMA==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
 
 react-error-overlay@^6.0.3, react-error-overlay@^6.0.7:
   version "6.0.7"


### PR DESCRIPTION
## Summary
inevitably there will be render errors when rendering, and this adds a basic error boundary. we can add more specific error messages and stuff later if needed - anything is better than just a blank page due to rendering errors

this uses the package 'react-error-boundary' for an easier abstraction
over the stock one in React

## Steps

- [ ] My change requires a change to the documentation
- [ ] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #ISSUE_NUMBER_HERE

<!--
Example:
This PR resolves #22
-->

<!--
Thank you for your contribution to rapid!
-->
