### PR TITLE
Enable use of importing components via aliases

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const { alias } = require('../webpack.common')
+
 module.exports = {
   stories: ['../src/**/*.stories.js'],
   addons: [
@@ -5,4 +7,9 @@ module.exports = {
     '@storybook/addon-actions',
     '@storybook/addon-links',
   ],
+  webpackFinal: (webpackConfig) => {
+    Object.assign(webpackConfig.resolve.alias, alias)
+
+    return webpackConfig
+  },
 }

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const { alias } = require('./webpack.common')
+
+module.exports = function ({ env }) {
+  return {
+    reactScriptsVersion: 'react-scripts',
+    webpack: {
+      configure: (webpackConfig, { env, paths }) => {
+        Object.assign(webpackConfig.resolve.alias, alias)
+
+        return webpackConfig
+      },
+    },
+    devServer: (devServerConfig, { env, paths, proxy, allowedHost }) => {
+      // webpackConfig.port doesn't work here
+      return devServerConfig
+    },
+  }
+}

--- a/craco.config.js
+++ b/craco.config.js
@@ -13,6 +13,20 @@ module.exports = function ({ env }) {
         return webpackConfig
       },
     },
+    jest: {
+      configure: (jestConfig, { env, paths, resolve, rootDir }) => {
+        jestConfig.moduleNameMapper['^~atoms(.*)$'] =
+          '<rootDir>/src/components/atoms$1'
+        jestConfig.moduleNameMapper['^~molecules(.*)$'] =
+          '<rootDir>/src/components/molecules$1'
+        jestConfig.moduleNameMapper['^~organisms(.*)$'] =
+          '<rootDir>/src/components/organisms$1'
+        // this must be added last
+        jestConfig.moduleNameMapper['^~(.*)$'] = '<rootDir>/src$1'
+
+        return jestConfig
+      },
+    },
     devServer: (devServerConfig, { env, paths, proxy, allowedHost }) => {
       // webpackConfig.port doesn't work here
       return devServerConfig

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "react-wavify": "^1.3.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "start": "cross-env PORT=8080 craco start",
+    "build": "craco build",
+    "test": "craco test",
+    "eject": "craco eject",
     "format": "prettier --write src/",
     "format-check": "prettier --check src/",
     "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
@@ -51,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "@craco/craco": "^5.6.4",
     "@storybook/addon-actions": "^5.3.19",
     "@storybook/addon-links": "^5.3.19",
     "@storybook/addons": "^5.3.19",
@@ -65,12 +66,15 @@
     "@types/react-dom": "^16.9.0",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
+    "cross-env": "^7.0.2",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-simple-import-sort": "^5.0.3",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
+    "patch-package": "^6.2.2",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.0.5",
     "typescript": "^3.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
     "lint-workflow": "eslint '*/**/*.{js,ts,tsx}' --quiet",
     "storybook": "start-storybook -p 9009 -s public",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -s public",
+    "postinstall": "patch-package"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/patches/react-scripts+3.4.1.patch
+++ b/patches/react-scripts+3.4.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js b/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+index ebd93d7..23d6c58 100644
+--- a/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js
++++ b/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+@@ -128,7 +128,7 @@ function verifyTypeScriptSetup() {
+       parsedValue: ts.JsxEmit.React,
+       suggested: 'react',
+     },
+-    paths: { value: undefined, reason: 'aliased imports are not supported' },
++    // paths: { value: undefined, reason: 'aliased imports are not supported' },
+   };
+ 
+   const formatDiagnosticHost = {

--- a/patches/react-scripts+3.4.1.patch
+++ b/patches/react-scripts+3.4.1.patch
@@ -1,13 +1,22 @@
 diff --git a/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js b/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js
-index ebd93d7..23d6c58 100644
+index ebd93d7..c94ffbc 100644
 --- a/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js
 +++ b/node_modules/react-scripts/scripts/utils/verifyTypeScriptSetup.js
-@@ -128,7 +128,7 @@ function verifyTypeScriptSetup() {
-       parsedValue: ts.JsxEmit.React,
-       suggested: 'react',
-     },
--    paths: { value: undefined, reason: 'aliased imports are not supported' },
-+    // paths: { value: undefined, reason: 'aliased imports are not supported' },
-   };
+@@ -239,7 +239,7 @@ function verifyTypeScriptSetup() {
+     } else {
+       console.warn(
+         chalk.bold(
+-          'The following changes are being made to your',
++          'The following changes are [NOT (this has been patched out)] being made to your',
+           chalk.cyan('tsconfig.json'),
+           'file:'
+         )
+@@ -249,7 +249,7 @@ function verifyTypeScriptSetup() {
+       });
+       console.warn();
+     }
+-    writeJson(paths.appTsConfig, appTsConfig);
++    // writeJson(paths.appTsConfig, appTsConfig);
+   }
  
-   const formatDiagnosticHost = {
+   // Reference `react-scripts` types

--- a/src/components/molecules/CommunityCard.tsx
+++ b/src/components/molecules/CommunityCard.tsx
@@ -1,9 +1,9 @@
 import { Box, Flex, Text } from '@chakra-ui/core'
 import React from 'react'
 
-import LogoBackdrop from '../atoms/LogoBackdrop'
-import MemberCount from '../atoms/MemberCount'
-import { commonShadow } from '../common'
+import { commonShadow } from '~/components/common'
+import LogoBackdrop from '~atoms/LogoBackdrop'
+import MemberCount from '~atoms/MemberCount'
 
 const bigBorderRadiusTop = '50px'
 const mediumBorderRadiusBottom = '25px'

--- a/src/components/molecules/CommunityCardSmall.tsx
+++ b/src/components/molecules/CommunityCardSmall.tsx
@@ -1,9 +1,9 @@
 import { Flex, Text } from '@chakra-ui/core'
 import React from 'react'
 
-import LogoBackdrop from '../atoms/LogoBackdrop'
-import MemberCount from '../atoms/MemberCount'
-import { mediumBorderRadius } from '../common'
+import { mediumBorderRadius } from '~/components/common'
+import LogoBackdrop from '~atoms/LogoBackdrop'
+import MemberCount from '~atoms/MemberCount'
 
 interface communityCardSmallProps {
   title: string

--- a/src/components/molecules/FriendItem.tsx
+++ b/src/components/molecules/FriendItem.tsx
@@ -1,12 +1,11 @@
-import { Box, Flex, Text } from '@chakra-ui/core'
-import { Divider } from '@chakra-ui/core'
+import { Box, Divider, Flex, Text } from '@chakra-ui/core'
 import { faEllipsisV, faTint } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
 
-import IconCall from '../atoms/IconCall'
-import IconMessage from '../atoms/IconMessage'
-import UserAvatar from '../atoms/UserAvatar'
+import IconCall from '~atoms/IconCall'
+import IconMessage from '~atoms/IconMessage'
+import UserAvatar from '~atoms/UserAvatar'
 
 interface userSchema {
   name: string

--- a/src/components/molecules/FriendSearchBar.tsx
+++ b/src/components/molecules/FriendSearchBar.tsx
@@ -1,8 +1,8 @@
 import { Box, Flex } from '@chakra-ui/core'
 import React from 'react'
 
-import FriendSearchBarButton from '../atoms/FriendSearchBarButton'
-import SearchBar from '../atoms/SearchBar'
+import FriendSearchBarButton from '~atoms/FriendSearchBarButton'
+import SearchBar from '~atoms/SearchBar'
 
 const FriendSearchBar = () => {
   return (

--- a/src/components/molecules/GroupDmCard.tsx
+++ b/src/components/molecules/GroupDmCard.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Tag, Text } from '@chakra-ui/core'
 import React from 'react'
 
-import ImageGrid from '../atoms/ImageGrid'
+import ImageGrid from '~atoms/ImageGrid'
 
 interface groupDmCardProps {
   groupDm: {

--- a/src/components/organisms/AllCommunities.tsx
+++ b/src/components/organisms/AllCommunities.tsx
@@ -1,8 +1,8 @@
 import { Box, Stack } from '@chakra-ui/core'
 import React from 'react'
 
-import GroupHeading from '../atoms/GroupHeading'
-import CommunityCardSmall from '../molecules/CommunityCardSmall'
+import GroupHeading from '~atoms/GroupHeading'
+import CommunityCardSmall from '~molecules/CommunityCardSmall'
 
 export default function AllCommunities() {
   return (

--- a/src/components/organisms/DirectMessages.tsx
+++ b/src/components/organisms/DirectMessages.tsx
@@ -1,11 +1,11 @@
 import { Box, Flex, Text } from '@chakra-ui/core'
 import React from 'react'
 
-import { dms, groupDms } from '../../util/dummyData'
-import SearchBar from '../atoms/SearchBar'
-import WordWithLine from '../atoms/WordWithLine'
-import GroupDmCard from '../molecules/GroupDmCard'
-import UserDmCard from '../molecules/UserDmCard'
+import { dms, groupDms } from '~/util/dummyData'
+import SearchBar from '~atoms/SearchBar'
+import WordWithLine from '~atoms/WordWithLine'
+import GroupDmCard from '~molecules/GroupDmCard'
+import UserDmCard from '~molecules/UserDmCard'
 
 const DirectMessages = () => {
   return (

--- a/src/components/organisms/FriendList.tsx
+++ b/src/components/organisms/FriendList.tsx
@@ -1,10 +1,11 @@
 import { Flex } from '@chakra-ui/core'
 import React from 'react'
 
-import { offlineUsers, onlineUsers } from '../../util/dummyData'
-import WordWithLine from '../atoms/WordWithLine'
-import FriendItem from '../molecules/FriendItem'
-import FriendSearchBar from '../molecules/FriendSearchBar'
+import { offlineUsers, onlineUsers } from '~/util/dummyData'
+import WordWithLine from '~atoms/WordWithLine'
+import FriendItem from '~molecules/FriendItem'
+import FriendSearchBar from '~molecules/FriendSearchBar'
+
 import ThemeX from '../theme'
 
 const FriendList = () => {

--- a/src/components/organisms/NavSidebar.tsx
+++ b/src/components/organisms/NavSidebar.tsx
@@ -11,9 +11,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import IconMentions from '../atoms/IconMentions'
-import IconSettings from '../atoms/IconSettings'
-import UserAvatar from '../atoms/UserAvatar'
+import IconMentions from '~atoms/IconMentions'
+import IconSettings from '~atoms/IconSettings'
+import UserAvatar from '~atoms/UserAvatar'
+
 import { commonShadow } from '../common'
 
 interface navSidebarProps {

--- a/src/components/organisms/PinnedCommunities.tsx
+++ b/src/components/organisms/PinnedCommunities.tsx
@@ -1,8 +1,8 @@
 import { Box, Stack } from '@chakra-ui/core'
 import React from 'react'
 
-import GroupHeading from '../atoms/GroupHeading'
-import CommunityCardSmall from '../molecules/CommunityCardSmall'
+import GroupHeading from '~atoms/GroupHeading'
+import CommunityCardSmall from '~molecules/CommunityCardSmall'
 
 export default function PinnedCommunities() {
   return (

--- a/src/components/organisms/PopularDrops.tsx
+++ b/src/components/organisms/PopularDrops.tsx
@@ -1,8 +1,8 @@
 import { Stack, Text } from '@chakra-ui/core'
 import React from 'react'
 
-import GroupHeading from '../atoms/GroupHeading'
-import DropsList from '../molecules/DropsList'
+import GroupHeading from '~atoms/GroupHeading'
+import DropsList from '~molecules/DropsList'
 
 export default function PopularDrops() {
   return (

--- a/src/components/organisms/RecommendedCommunities.tsx
+++ b/src/components/organisms/RecommendedCommunities.tsx
@@ -1,9 +1,8 @@
-import { Box, Stack } from '@chakra-ui/core'
-import { Text } from '@chakra-ui/core'
+import { Box, Stack, Text } from '@chakra-ui/core'
 import React from 'react'
 
-import GroupHeading from '../atoms/GroupHeading'
-import CommunityCard from '../molecules/CommunityCard'
+import GroupHeading from '~atoms/GroupHeading'
+import CommunityCard from '~molecules/CommunityCard'
 
 export default function RecommendedCommunities() {
   return (

--- a/src/components/organisms/TrendingCommunities.tsx
+++ b/src/components/organisms/TrendingCommunities.tsx
@@ -1,8 +1,8 @@
 import { Stack, Text } from '@chakra-ui/core'
 import React from 'react'
 
-import GroupHeading from '../atoms/GroupHeading'
-import CommunityCard from '../molecules/CommunityCard'
+import GroupHeading from '~atoms/GroupHeading'
+import CommunityCard from '~molecules/CommunityCard'
 
 export default function Trending() {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,6 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
-
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -36,17 +35,20 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
-
     /* Additional Checks */
     // "noUnusedLocals": true,                /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
     /* Module Resolution Options */
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "paths": {
+      "~/*": ["src/*"],
+      "~atoms/*": ["src/components/atoms/*"],
+      "~molecules/*": ["src/components/molecules/*"],
+      "~organisms/*": ["src/components/molecules/*"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
@@ -54,17 +56,14 @@
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "skipLibCheck": true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+/**
+ * @fileoverview Common Webpack config for CRA and Storybook configs
+ */
+
+const path = require('path')
+
+/** @type Record<string, string> */
+const alias = {}
+alias['~'] = path.join(__dirname, 'src')
+alias['~atoms'] = path.join(__dirname, 'src/components/atoms')
+alias['~molecules'] = path.join(__dirname, 'src/components/molecules')
+alias['~organisms'] = path.join(__dirname, 'src/components/organisms')
+
+module.exports = {
+  alias,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,6 +1160,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@craco/craco@^5.6.4":
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-5.6.4.tgz#de7a707c727864f39e6afc192fb6732c3ca45f90"
+  integrity sha512-/Qi6yPMOBC7SEZJEDI5vYaPiGFs7HzO4AAZkGB0W3MX2OCw4u4FZC+ZO6TBptGzM3QLrF7WFt5AyQnXhNBcn3A==
+  dependencies:
+    cross-spawn "^7.0.0"
+    lodash "^4.17.15"
+    webpack-merge "^4.2.2"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -2893,6 +2902,11 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 abab@^2.0.0:
   version "2.0.3"
@@ -4843,6 +4857,13 @@ create-react-context@0.3.0, create-react-context@^0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4871,7 +4892,7 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -6478,6 +6499,14 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -6615,7 +6644,7 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^4.0.2:
+fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
@@ -6624,7 +6653,7 @@ fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -8683,6 +8712,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -10152,6 +10188,24 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -11060,6 +11114,11 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -14050,6 +14109,13 @@ webpack-manifest-plugin@2.2.0:
     lodash ">=3.5 <5"
     object.entries "^1.1.0"
     tapable "^1.0.0"
+
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
 
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,9 +2130,9 @@
     loader-utils "^1.2.3"
 
 "@testing-library/dom@*":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.21.5.tgz#d87312efc5039313f9ea246ed722d808f2ffcbb3"
-  integrity sha512-zZqC5T/9Upjs0/3hyrYNpGxw75dr/bLLD27pUdb3WWJ50JHwutvnQ1FJNHbVth9f2hLzEnh7hBdZ9pD++8pJ8g==
+  version "7.21.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.21.6.tgz#e69349184e558472fe3f54eb67e6960d080925c3"
+  integrity sha512-Xj6AMM9Xb24NSeann91fmXFuyJEzZ1lpVgiaPiy/KY2pNX9y4OeDrEm2ZYZt6mfZgFSGZW0eEWpF7YfcvRq5LQ==
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@types/aria-query" "^4.2.0"
@@ -3016,7 +3016,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
@@ -4250,9 +4250,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097:
-  version "1.0.30001107"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001107.tgz#809360df7a5b3458f627aa46b0f6ed6d5239da9a"
-  integrity sha512-86rCH+G8onCmdN4VZzJet5uPELII59cUzDphko3thQFgAQG1RNa+sVLDoALIhRYmflo5iSIzWY3vu1XTWtNMQQ==
+  version "1.0.30001109"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz#a9f3f26a0c3753b063d7acbb48dfb9c0e46f2b19"
+  integrity sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5159,9 +5159,9 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
     cssom "0.3.x"
 
 csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.9:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
-  integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
+  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -5451,9 +5451,9 @@ dom-accessibility-api@^0.3.0:
   integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
 dom-accessibility-api@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.6.tgz#f3f2af68aee01b1c862f37918d41841bb1aaf92a"
-  integrity sha512-qxFVFR/ymtfamEQT/AsYLe048sitxFCoCHiM+vuOdR3fE94i3so2SCFJxyz/RxV69PZ+9FgToYWOd7eqJqcbYw==
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.7.tgz#31d01c113af49f323409b3ed09e56967aba485a8"
+  integrity sha512-5+GzhTpCQYHz4NjL8loYTDVBnXIjNLBadWQBKxXk+osFEplLt3EsSYBu2YZcdZ8QqrvCHgW6TSMGMbmgfhrn2g==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -5598,9 +5598,9 @@ ejs@^2.7.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.488:
-  version "1.3.510"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.510.tgz#dee781ff8b595c0deb60172b75d50b6889757eda"
-  integrity sha512-sLtGB0znXdmo6lM8hy5wTVo+fLqvIuO8hEpgc0DvPmFZqvBu/WB7AarEwhxVKjf3rVbws/rC8Xf+AlsOb36lJQ==
+  version "1.3.514"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.514.tgz#107499c28cb3c09fe6a863c19fc2202d5d9e8e41"
+  integrity sha512-8vb8zKIeGlZigeDzNWWthmGeLzo5CC43Lc+CZshMs7UXFVMPNLtXJGa/txedpu3OJFrXXVheBwp9PqOJJlHQ8w==
 
 element-resize-detector@^1.2.1:
   version "1.2.1"
@@ -6991,11 +6991,11 @@ har-schema@^2.0.0:
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
-  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
-    ajv "^6.5.5"
+    ajv "^6.12.3"
     har-schema "^2.0.0"
 
 harmony-reflect@^1.4.6:
@@ -8819,9 +8819,9 @@ lint-staged@^10.2.11:
     stringify-object "^3.3.0"
 
 listr2@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.4.0.tgz#aadb094f1f16a96bb9c4dc9b9c3e1d24b1709803"
-  integrity sha512-Hj2ECZdAxDkuYFtIKE35PgdMSqMp0muIhJRG5EyV5pOWFEUmKUG+fhfFrvIUNGBQvvi7wQ41eKTxDBisfvDjFQ==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.4.1.tgz#006fc94ae77b3195403cbf3a4a563e2d6366224f"
+  integrity sha512-8pYsCZCztr5+KAjReLyBeGhLV0vaQ2Du/eMe/ux9QAfQl7efiWejM1IWjALh0zHIRYuIbhQ8N2KztZ4ci56pnQ==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"
@@ -9417,7 +9417,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -10434,13 +10434,13 @@ popper.js@^1.14.4, popper.js@^1.14.7, popper.js@^1.15.0:
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.25:
-  version "1.0.27"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.27.tgz#a41333c116b5e5f3d380f9745ac2f35084c4c758"
-  integrity sha512-bJ3U3MThKnyJ9Dx1Idtm5pQmxXqw08+XOHhi/Lie8OF1OlhVaBFhsntAIhkZYjfDcCzszSr0w1yCbccThhzgxQ==
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
+  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
   dependencies:
     async "^2.6.2"
     debug "^3.1.1"
-    mkdirp "^0.5.1"
+    mkdirp "^0.5.5"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -14162,9 +14162,9 @@ webpack@4.42.0:
     webpack-sources "^1.4.1"
 
 webpack@^4.33.0, webpack@^4.38.0:
-  version "4.44.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.0.tgz#3b08f88a89470175f036f4a9496b8a0428668802"
-  integrity sha512-wAuJxK123sqAw31SpkPiPW3iKHgFUiKvO7E7UZjtdExcsRe3fgav4mvoMM7vvpjLHVoJ6a0Mtp2fzkoA13e0Zw==
+  version "4.44.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.1.tgz#17e69fff9f321b8f117d1fda714edfc0b939cc21"
+  integrity sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"


### PR DESCRIPTION
## Description

works in all environments
- added to CRA webpack
- added to storybook webpack
- added to `tsconfig.json` (intellisense)
- added to jest
- `react-scripts` package has been patched to enable use of the `paths` propery in tsconfig (and won't overwrite tsconfig anymore /  cause build to fail)

for example, if you 
## Steps

- [x] My change requires a change to the documentation
- [x] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

<!--
Example:
This PR resolves #22
-->

<!--
Thank you for your contribution to rapid!
-->
