### PR TITLE
Make FindInterface icons line up

### DIFF
--- a/src/components/organisms/FindInterface.tsx
+++ b/src/components/organisms/FindInterface.tsx
@@ -38,6 +38,7 @@ export default function FindInterface() {
             size="lg"
             cursor="pointer"
             icon={faGraduationCap}
+            fixedWidth
           />
           <Text color={stdLightGrey} marginLeft="15px">
             Education
@@ -49,6 +50,7 @@ export default function FindInterface() {
             size="lg"
             cursor="pointer"
             icon={faHeadphones}
+            fixedWidth
           />
           <Text color={stdLightGrey} marginLeft="15px">
             Gaming
@@ -60,6 +62,7 @@ export default function FindInterface() {
             size="lg"
             cursor="pointer"
             icon={faCamera}
+            fixedWidth
           />
           <Text color={stdLightGrey} marginLeft="15px">
             Movies & TV
@@ -71,6 +74,7 @@ export default function FindInterface() {
             size="lg"
             cursor="pointer"
             icon={faMusic}
+            fixedWidth
           />
           <Text color={stdLightGrey} marginLeft="15px">
             Music
@@ -82,6 +86,7 @@ export default function FindInterface() {
             size="lg"
             cursor="pointer"
             icon={faHammer}
+            fixedWidth
           />
           <Text color={stdLightGrey} marginLeft="15px">
             Politics
@@ -93,6 +98,7 @@ export default function FindInterface() {
             size="lg"
             cursor="pointer"
             icon={faBasketballBall}
+            fixedWidth
           />
           <Text color={stdLightGrey} marginLeft="15px">
             Sports
@@ -104,6 +110,7 @@ export default function FindInterface() {
             size="lg"
             cursor="pointer"
             icon={faLaptopCode}
+            fixedWidth
           />
           <Text color={stdLightGrey} marginLeft="15px">
             Technology


### PR DESCRIPTION
## Description

This PR makes the icons in the `FindInterface` component line up properly.

#### Before
![image](https://user-images.githubusercontent.com/34525547/88967865-632ea380-d27c-11ea-8c99-c1230fadc8c5.png)
#### After
![image](https://user-images.githubusercontent.com/34525547/88967822-4f833d00-d27c-11ea-8427-8259bf3de9e6.png)

## Steps

- [ ] My change requires a change to the documentation
- [ ] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #ISSUE_NUMBER_HERE

<!--
Example:
This PR resolves #22
-->

<!--
Thank you for your contribution to rapid!
-->
