### PR TITLE
fixed a typo on line 8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ## Requesting Features/Reporting Bugs
 
 1. Click on the "Issues" tab in the repo.
-2. Make sure that the issue does exist already be searching for it.
+2. Make sure that the issue doesn't already exist before opening one
 3. Pick the issue template.
 4. Fill in the issue template.
 


### PR DESCRIPTION
changed "Make sure that the issue does exist already be searching for it." to "Make sure that the issue doesn't already exist before opening one"

## Description

<!--
Describe your changes in detail
-->

## Steps

- [ ] My change requires a change to the documentation
- [ ] I have updated the accessible documentation according
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #ISSUE_NUMBER_HERE

<!--
Example:
This PR resolves #22
-->

<!--
Thank you for your contribution to rapid!
-->

## Original Design Screenshot

![]()

## Coded Component

![]()
